### PR TITLE
Changes to fulfill CI requirements

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -57,4 +57,4 @@ jobs:
       # 5. ~/.config/mypy/config
       # 6. ~/.mypy.ini
       # https://mypy.readthedocs.io/en/stable/config_file.html
-      run: mypy lightning_gpt
+      run: mypy lightning_gpt/ --pretty

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -22,9 +22,6 @@ jobs:
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v3
-      with:
-        submodules: recursive
-
     - name: Set up Python 🐍 3.9
       uses: actions/setup-python@v4
       with:
@@ -33,7 +30,6 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
-
     - name: pip cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[test]' --extra-index-url https://download.pytorch.org/whl/cpu/torch_stable.html
-        pip install mypy==1.5.0 types-setuptools # don't use --upgrade to respect the version installed via setup.py
+        pip install mypy==1.5.0  # don't use --upgrade to respect the version installed via setup.py
         pip list
 
     - name: Check typing
@@ -57,4 +57,4 @@ jobs:
       # 5. ~/.config/mypy/config
       # 6. ~/.mypy.ini
       # https://mypy.readthedocs.io/en/stable/config_file.html
-      run: mypy lightning_gpt/ --pretty
+      run: mypy

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[test]' --extra-index-url https://download.pytorch.org/whl/cpu/torch_stable.html
-        pip install mypy==0.982 types-setuptools # don't use --upgrade to respect the version installed via setup.py
+        pip install mypy==1.1.0 types-setuptools # don't use --upgrade to respect the version installed via setup.py
         pip list
 
     - name: Check typing

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -57,4 +57,4 @@ jobs:
       # 5. ~/.config/mypy/config
       # 6. ~/.mypy.ini
       # https://mypy.readthedocs.io/en/stable/config_file.html
-      run: mypy --exclude naogpt --exclude mingpt
+      run: mypy lightning_gpt

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -57,4 +57,4 @@ jobs:
       # 5. ~/.config/mypy/config
       # 6. ~/.mypy.ini
       # https://mypy.readthedocs.io/en/stable/config_file.html
-      run: mypy
+      run: mypy --exclude naogpt --exclude mingpt

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[test]' --extra-index-url https://download.pytorch.org/whl/cpu/torch_stable.html
-        pip install mypy==1.1.0 types-setuptools # don't use --upgrade to respect the version installed via setup.py
+        pip install mypy==1.5.0 types-setuptools # don't use --upgrade to respect the version installed via setup.py
         pip list
 
     - name: Check typing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
   autoupdate_schedule: quarterly
   # submodules: true
-  skip: [isort]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ ci:
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
   autoupdate_schedule: quarterly
   # submodules: true
+  skip: [isort]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/bench_fsdp_mingpt.py
+++ b/app/bench_fsdp_mingpt.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import Any, Tuple, TYPE_CHECKING
 from urllib.request import urlopen
 
 import lightning as L

--- a/app/bench_fsdp_mingpt.py
+++ b/app/bench_fsdp_mingpt.py
@@ -6,8 +6,6 @@ import lightning as L
 if TYPE_CHECKING:
     from lightning import LightningModule
 
-from typing import Literal, Union
-
 import torch
 from torch.utils.data import DataLoader
 

--- a/app/bench_fsdp_mingpt.py
+++ b/app/bench_fsdp_mingpt.py
@@ -42,16 +42,7 @@ class FSDPMinGPTBench(bench.Bench):
         return model, dataloader
 
     def train(self, model: "LightningModule", dataloader: DataLoader) -> float:
-        assert isinstance(
-            self.precision,
-            type(
-                Union[
-                    Literal[64, 32, 16],
-                    Literal["16-mixed", "bf16-mixed", "32-true", "64-true"],
-                    Literal["64", "32", "16", "bf16"],
-                ]
-            ),
-        )
+        self._check_precision()
         trainer = L.Trainer(
             fast_dev_run=True,
             max_epochs=self.max_epochs,

--- a/app/bench_single_mingpt.py
+++ b/app/bench_single_mingpt.py
@@ -6,8 +6,6 @@ import lightning as L
 if TYPE_CHECKING:
     from lightning import LightningModule
 
-from typing import Literal, Union
-
 import torch
 import torch._dynamo
 from torch.utils.data import DataLoader

--- a/app/bench_single_mingpt.py
+++ b/app/bench_single_mingpt.py
@@ -48,16 +48,7 @@ class GPTBench(bench.Bench):
         model: "LightningModule",
         dataloader: torch.utils.data.DataLoader,
     ) -> Optional[float]:
-        assert isinstance(
-            self.precision,
-            type(
-                Union[
-                    Literal[64, 32, 16],
-                    Literal["16-mixed", "bf16-mixed", "32-true", "64-true"],
-                    Literal["64", "32", "16", "bf16"],
-                ]
-            ),
-        )
+        self._check_precision()
         trainer = L.Trainer(
             max_epochs=self.max_epochs,
             gradient_clip_val=1.0,

--- a/app/bench_single_mingpt.py
+++ b/app/bench_single_mingpt.py
@@ -6,6 +6,8 @@ import lightning as L
 if TYPE_CHECKING:
     from lightning import LightningModule
 
+from typing import Literal, Union
+
 import torch
 import torch._dynamo
 from torch.utils.data import DataLoader
@@ -46,17 +48,27 @@ class GPTBench(bench.Bench):
         model: "LightningModule",
         dataloader: torch.utils.data.DataLoader,
     ) -> Optional[float]:
+        assert isinstance(
+            self.precision,
+            type(
+                Union[
+                    Literal[64, 32, 16],
+                    Literal["16-mixed", "bf16-mixed", "32-true", "64-true"],
+                    Literal["64", "32", "16", "bf16"],
+                ]
+            ),
+        )
         trainer = L.Trainer(
             max_epochs=self.max_epochs,
             gradient_clip_val=1.0,
             accelerator="cuda",
             devices=1,
-            precision=self.precision,
+            precision=self.precision,  # type: ignore
             enable_progress_bar=False,
             enable_model_summary=False,
             enable_checkpointing=False,
             logger=False,
-            replace_sampler_ddp=False,
+            use_distributed_sampler=False,
             num_sanity_val_steps=0,
             reload_dataloaders_every_n_epochs=1000,
         )

--- a/app/bench_single_mingpt.py
+++ b/app/bench_single_mingpt.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import Any, Optional, Tuple, TYPE_CHECKING
 from urllib.request import urlopen
 
 import lightning as L

--- a/app/bench_vanilla_mingpt.py
+++ b/app/bench_vanilla_mingpt.py
@@ -2,10 +2,10 @@ from typing import Any, Optional, Tuple
 from urllib.request import urlopen
 
 import lightning as L
-import mingpt.model
 import torch
 import torch._dynamo
 
+import mingpt.model
 from lightning_gpt import bench, data, models
 
 

--- a/lightning_gpt/__init__.py
+++ b/lightning_gpt/__init__.py
@@ -2,14 +2,7 @@ from lightning_gpt.__about__ import *  # noqa: F401, F403
 from lightning_gpt.bench import Bench, BenchRun
 from lightning_gpt.callbacks import CUDAMetricsCallback
 from lightning_gpt.data import CharDataset
-from lightning_gpt.models import (
-    DeepSpeedMinGPT,
-    DeepSpeedNanoGPT,
-    FSDPMinGPT,
-    FSDPNanoGPT,
-    MinGPT,
-    NanoGPT,
-)
+from lightning_gpt.models import DeepSpeedMinGPT, DeepSpeedNanoGPT, FSDPMinGPT, FSDPNanoGPT, MinGPT, NanoGPT
 
 __all__ = [
     "MinGPT",

--- a/lightning_gpt/bench.py
+++ b/lightning_gpt/bench.py
@@ -54,17 +54,17 @@ class BenchRun(LightningFlow):
     # def configure_layout(self):
     #     # return [{"name": "Training Logs", "content": self.tensorboard_work.url}]
 
-    def _check_precision(self):
-        if not isinstance(self.precision, (int, str)):
-            raise ValueError(f"Unsupported precision of type {type(self.precision)}.")
-        if self.precision not in (64, 32, 16, "64", "32", "16", "bf16", "16-mixed", "bf16-mixed", "32-true", "64-true"):
-            raise ValueError(f"Selected precision {self.precision} is not supported")
-
 
 class Bench(LightningWork):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         self.results: Dict[str, Dict[str, Union[List[int], List[float]]]] = {}
+
+    def _check_precision(self) -> None:
+        if not isinstance(self.precision, (int, str)):
+            raise ValueError(f"Unsupported precision of type {type(self.precision)}.")
+        if self.precision not in (64, 32, 16, "64", "32", "16", "bf16", "16-mixed", "bf16-mixed", "32-true", "64-true"):
+            raise ValueError(f"Selected precision {self.precision} is not supported")
 
     def run_benchmark(
         self,

--- a/lightning_gpt/bench.py
+++ b/lightning_gpt/bench.py
@@ -54,6 +54,12 @@ class BenchRun(LightningFlow):
     # def configure_layout(self):
     #     # return [{"name": "Training Logs", "content": self.tensorboard_work.url}]
 
+    def _check_precision(self):
+        if not isinstance(self.precision, (int, str)):
+            raise ValueError(f"Unsupported precision of type {type(self.precision)}.")
+        if self.precision not in (64, 32, 16, "64", "32", "16", "bf16", "16-mixed", "bf16-mixed", "32-true", "64-true"):
+            raise ValueError(f"Selected precision {self.precision} is not supported")
+
 
 class Bench(LightningWork):
     def __init__(self, *args: Any, **kwargs: Any):

--- a/lightning_gpt/models.py
+++ b/lightning_gpt/models.py
@@ -2,13 +2,14 @@ import functools
 import warnings
 from typing import Any, Optional, Tuple
 
-import mingpt.model
-import mingpt.trainer
-import nanogpt.model
 import torch.optim
 from lightning import LightningModule
 from lightning.pytorch.strategies.deepspeed import _DEEPSPEED_AVAILABLE
 from lightning_utilities.core.overrides import is_overridden
+
+import mingpt.model
+import mingpt.trainer
+import nanogpt.model
 from mingpt.utils import CfgNode
 
 MINGPT_PRESETS = {

--- a/lightning_gpt/models.py
+++ b/lightning_gpt/models.py
@@ -284,8 +284,8 @@ class FSDPNanoGPT(NanoGPT):
 
 def _register_gpt_strategy() -> None:
     from lightning.pytorch.strategies import StrategyRegistry
-    from lightning.pytorch.strategies.fully_sharded_native import (
-        DDPFullyShardedNativeStrategy,
+    from lightning.pytorch.strategies.fsdp import (
+        FSDPStrategy,
     )
     from torch.distributed.fsdp import BackwardPrefetch
     from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
@@ -299,7 +299,7 @@ def _register_gpt_strategy() -> None:
 
     StrategyRegistry.register(
         name="fsdp-gpt",
-        strategy=DDPFullyShardedNativeStrategy,
+        strategy=FSDPStrategy,
         description="FSDP strategy with memory optimizations enabled for GPT large scale pretraining.",
         auto_wrap_policy=auto_wrap_policy,
         activation_checkpointing=[nanogpt.model.Block, mingpt.model.Block],

--- a/lightning_gpt/models.py
+++ b/lightning_gpt/models.py
@@ -286,9 +286,7 @@ class FSDPNanoGPT(NanoGPT):
 
 def _register_gpt_strategy() -> None:
     from lightning.pytorch.strategies import StrategyRegistry
-    from lightning.pytorch.strategies.fsdp import (
-        FSDPStrategy,
-    )
+    from lightning.pytorch.strategies.fsdp import FSDPStrategy
     from torch.distributed.fsdp import BackwardPrefetch
     from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 

--- a/lightning_gpt/models.py
+++ b/lightning_gpt/models.py
@@ -230,6 +230,7 @@ class FSDPMinGPT(MinGPT):
         _register_gpt_strategy()
 
     def configure_optimizers(self) -> torch.optim.AdamW:
+        assert isinstance(self.trainer.model, torch.nn.Module)
         return _get_fsdp_optimizers(
             self.trainer.model,
             weight_decay=self.mingpt_trainer_config.weight_decay,
@@ -274,6 +275,7 @@ class FSDPNanoGPT(NanoGPT):
         _register_gpt_strategy()
 
     def configure_optimizers(self) -> torch.optim.AdamW:
+        assert isinstance(self.trainer.model, torch.nn.Module)
         return _get_fsdp_optimizers(
             self.trainer.model,
             weight_decay=self.nanogpt_trainer_config.weight_decay,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,12 @@ order_by_type = "False"
 
 [tool.mypy]
 files = [
-    "lightning_gpt/*.py",
-    "app/*.py",
+    "lightning_gpt/"
 ]
 # This section is for folders with "-" as they are not valid python modules
 exclude = [
-    "mingpt/*.py",
-    "nanogpt/*.py"
+    '^mingpt/',
+    '^nanogpt/'
 ]
 install_types = "True"
 non_interactive = "True"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,19 @@
 line-length = 120
 target-version = ['py38', 'py39', 'py310']
 
+
+[tool.isort]
+known_first_party = [
+    "lightning_gpt",
+    "nanogpt",
+    "mingpt",
+]
+profile = "black"
+line_length = 120
+force_sort_within_sections = "False"
+order_by_type = "False"
+
+
 [tool.mypy]
 files = [
     "lightning_gpt/*.py",

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 coverage==6.5.0
-codecov==2.1.12
+codecov==2.1.13
 pytest==7.2.0
 pytest-cov==4.0.0
 lightning>=1.8.4


### PR DESCRIPTION
This includes various changes to get the code to pass the CI checis:
1. Codeconv version 2.1.12 appears to have been pulled from PyPI for security reasons (see https://github.com/codecov/python-standard/issues/31 ) and so the version has been bumped up to 2.1.13.
2. Skip isort for pre-commit.ci to avoid it conflicting with the pre-commit worker checks.
3. Some additional type checking to get mypi to accept the code.
4. Some code renames, including changing DDPFullyShardedNativeStrategy to FSDPStrategy to account for changes to the Lightning API.

